### PR TITLE
Use some best pratice to include headers

### DIFF
--- a/src/cli/application.cpp
+++ b/src/cli/application.cpp
@@ -19,14 +19,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <cli/application.hpp>
+#include "application.hpp"
 
 #include <iostream>
 #include <algorithm>
 #include <cstring>
 
-#include <pinky/parse.hpp>
-#include <pinky/evaluation.hpp>
+#include "pinky/parse.hpp"
+#include "pinky/evaluation.hpp"
 
 
 void pinky::application::print_header() const

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <cli/application.hpp>
+#include "application.hpp"
 
 
 int main() 

--- a/src/pinky/CMakeLists.txt
+++ b/src/pinky/CMakeLists.txt
@@ -21,8 +21,6 @@ set(pinky-sources
 set(lib_name pinky)
 add_library(${lib_name} STATIC ${pinky-hearders} ${pinky-sources})
 
-target_include_directories(${lib_name} PRIVATE ${CMAKE_SOURCE_DIR}/src)
-
 target_compile_features(${lib_name} PRIVATE cxx_std_20)
 
 target_compile_options(${lib_name} PRIVATE 

--- a/src/pinky/cmap.hpp
+++ b/src/pinky/cmap.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <algorithm>
 
-#include <pinky/error.hpp>
+#include "error.hpp"
 
 
 namespace pinky

--- a/src/pinky/constant.hpp
+++ b/src/pinky/constant.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <pinky/cmap.hpp>
+#include "cmap.hpp"
 
 
 using namespace std::literals::string_view_literals;

--- a/src/pinky/evaluation.cpp
+++ b/src/pinky/evaluation.cpp
@@ -19,11 +19,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <pinky/evaluation.hpp>
+#include "evaluation.hpp"
 
-#include <pinky/constant.hpp>
-#include <pinky/operator.hpp>
-#include <pinky/function.hpp>
+#include "constant.hpp"
+#include "operator.hpp"
+#include "function.hpp"
 
 
 double pinky::postfix_evaluation(const std::vector<pinky::token>& tokens)

--- a/src/pinky/evaluation.hpp
+++ b/src/pinky/evaluation.hpp
@@ -23,7 +23,7 @@
 
 #include <vector>
 
-#include <pinky/token.hpp>
+#include "token.hpp"
 
 
 namespace pinky

--- a/src/pinky/function.cpp
+++ b/src/pinky/function.cpp
@@ -19,12 +19,12 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <pinky/function.hpp>
+#include "function.hpp"
 
 #include <cmath>
 
-#include <pinky/error.hpp>
-#include <pinky/cmap.hpp>
+#include "error.hpp"
+#include "cmap.hpp"
 
 
 double pinky::apply_function(const std::string& str_function, double x)

--- a/src/pinky/operator.cpp
+++ b/src/pinky/operator.cpp
@@ -19,11 +19,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <pinky/operator.hpp>
+#include "operator.hpp"
 
 #include <cmath>
 
-#include <pinky/error.hpp>
+#include "error.hpp"
 
 
 double pinky::binary_operation(const std::string& str_operator, double left_operand, double right_operand)

--- a/src/pinky/operator.hpp
+++ b/src/pinky/operator.hpp
@@ -23,7 +23,7 @@
 
 #include <string>
 
-#include <pinky/cmap.hpp>
+#include "cmap.hpp"
 
 
 using namespace std::literals::string_view_literals;

--- a/src/pinky/parse.cpp
+++ b/src/pinky/parse.cpp
@@ -19,13 +19,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <pinky/parse.hpp>
+#include "parse.hpp"
 
 #include <cctype>
 
-#include <pinky/error.hpp>
-#include <pinky/constant.hpp>
-#include <pinky/operator.hpp>
+#include "error.hpp"
+#include "constant.hpp"
+#include "operator.hpp"
 
 
 static inline bool is_digit(char c) { return std::isdigit(c) != 0; }

--- a/src/pinky/parse.hpp
+++ b/src/pinky/parse.hpp
@@ -24,7 +24,7 @@
 #include <string_view>
 #include <vector>
 
-#include <pinky/token.hpp>
+#include "token.hpp"
 
 
 namespace pinky

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ set(test_pinky_sources
 add_executable(${test_pinky_exe} ${test_pinky_sources})
 
 target_include_directories(${test_pinky_exe} PRIVATE 
-	${CMAKE_SOURCE_DIR}
+	${CMAKE_SOURCE_DIR}/vendor
 	${CMAKE_SOURCE_DIR}/src
 )
 

--- a/tests/test_cmap.cpp
+++ b/tests/test_cmap.cpp
@@ -1,6 +1,6 @@
-#include <vendor/catch2/catch.hpp>
+#include "catch2/catch.hpp"
 
-#include <pinky/cmap.hpp>
+#include "pinky/cmap.hpp"
 
 
 TEST_CASE("cmap - access to key which does not exist", "[core]")

--- a/tests/test_function.cpp
+++ b/tests/test_function.cpp
@@ -1,8 +1,8 @@
 #include <cmath>
 
-#include <vendor/catch2/catch.hpp>
+#include "catch2/catch.hpp"
 
-#include <pinky/function.hpp>
+#include "pinky/function.hpp"
 
 
 TEST_CASE("function - apply abs", "[core]")

--- a/tests/test_infix_to_postfix.cpp
+++ b/tests/test_infix_to_postfix.cpp
@@ -1,6 +1,6 @@
-#include <vendor/catch2/catch.hpp>
+#include "catch2/catch.hpp"
 
-#include <pinky/parse.hpp>
+#include "pinky/parse.hpp"
 
 
 TEST_CASE("infix_to_postfix - operation between two numbers", "[processing]")

--- a/tests/test_operator.cpp
+++ b/tests/test_operator.cpp
@@ -1,8 +1,8 @@
 #include <cmath>
 
-#include <vendor/catch2/catch.hpp>
+#include "catch2/catch.hpp"
 
-#include <pinky/operator.hpp>
+#include "pinky/operator.hpp"
 
 
 TEST_CASE("operator - binary operator plus", "[core]")

--- a/tests/test_pinky.cpp
+++ b/tests/test_pinky.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "vendor/catch2/catch.hpp"
+#include "catch2/catch.hpp"

--- a/tests/test_postfix_evaluation.cpp
+++ b/tests/test_postfix_evaluation.cpp
@@ -1,8 +1,8 @@
 #include <cmath>
 
-#include <vendor/catch2/catch.hpp>
+#include "catch2/catch.hpp"
 
-#include <pinky/evaluation.hpp>
+#include "pinky/evaluation.hpp"
 
 
 TEST_CASE("postfix_evaluation - operation between two numbers", "[processing]")

--- a/tests/test_tokenization.cpp
+++ b/tests/test_tokenization.cpp
@@ -1,6 +1,6 @@
-#include <vendor/catch2/catch.hpp>
+#include "catch2/catch.hpp"
 
-#include <pinky/parse.hpp>
+#include "pinky/parse.hpp"
 
 
 TEST_CASE("tokenization - expression with one number", "[processing]")


### PR DESCRIPTION
Use ".hpp" instead of <.hpp>
Remove -I compiler option if is not necessary 